### PR TITLE
Cross domain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,45 @@ Just add the following code to your AMP Pages:
 -  **Document Referrer**
 -  **Unique Pageview Id** (**`&_p`**)
 -  **Debug Mode Switch** (**`&_dbg=1`**)
--  **Regional Data Collection* (**`region1.analytics-debugger.com`**)  
+-  **Regional Data Collection* (**`region1.google-analytics-com`**)  
+-  **Document Referrer**
+-  **Cross Domain Tracking**
+-  **User Agent Client Hints**
 
 ## In-Build Events
 
 -  **Web Vitals**
 -  **Performance Timing** 
 
+## Cross-Domain Tracking
+To utilize the newly implemented core file session cross-linking feature, you can simply add a linker section to your <script>
+and specify the domains list along with your measurement IDs. 
+
+However, please note that AMP does not permit the definition of dynamic keys. Therefore, you must manually add the measurement ID and include multiple "ids"
+lines for each unique measurement ID you have.
+
+```javascript
+"linkers": {
+    "enabled": true,
+    "destinationDomains": ["*.extenaldomain.com"],
+    "_gl": {
+        "ids": {
+            "_ga_RNYCK86MYK": "${ga4SessionCookie}"
+        },
+        "proxyOnly": false
+    }
+}
+```
+It is important to note that if your measurement ID is "G-THYNGSTER", the "ids" key should be structured as "_ga_THYNGSTER". 
+After including these lines of code, when a user clicks on a crosslinked domain, the corresponding details will be transmitted to the destination domain.
+
+|Client ID|
+|Session ID|
+|Session Count|
+|Session Engaged|
+
+This ensures that the current user and session remain unchanged when the users navigate from your AMP to NON-AMP pages.
+ 
 ## Enable Debug Mode
 Add a ?_dbg=1 parameter to the current url to allow hits to show on GA4's DebugView
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Just add the following code to your AMP Pages:
 
 ## Cross-Domain Tracking
 To utilize the newly implemented core file session cross-linking feature, you can simply add a linker section to your <script>
-and specify the domains list along with your measurement IDs. 
+and specify the domains list along with your measurement IDs. Just after the vars: {} key.
 
 However, please note that AMP does not permit the definition of dynamic keys. Therefore, you must manually add the measurement ID and include multiple "ids"
 lines for each unique measurement ID you have.
@@ -120,10 +120,12 @@ lines for each unique measurement ID you have.
 It is important to note that if your measurement ID is "G-THYNGSTER", the "ids" key should be structured as "_ga_THYNGSTER". 
 After including these lines of code, when a user clicks on a crosslinked domain, the corresponding details will be transmitted to the destination domain.
 
-|Client ID|
-|Session ID|
-|Session Count|
-|Session Engaged|
+|Data Key|Description|
+|--|--|
+|Client ID| Current Client Id from _ga cookie|
+|Session ID| Current Session ID to keep the session alive|
+|Session Count| Current Session Count so it get written on the destination cookie|
+|Session Engagement| If session is currently engaged|
 
 This ensures that the current user and session remain unchanged when the users navigate from your AMP to NON-AMP pages.
  

--- a/ga4.json
+++ b/ga4.json
@@ -72,7 +72,8 @@
         "clientId": "CLIENT_ID(AMP_ECID_GOOGLE,,_ga,true)",
         "dataSource": "AMP",
         "isDebugEnabled": "$IF($EQUALS(QUERY_PARAM(_dbg),1), _dbg, __dbg)",
-        "endpoint": "$IF(${DISABLE_REGIONAL_DATA_COLLECTION},https://${GA4_ENDPOINT_HOSTNAME}, https://$IF($EQUALS($MATCH(${timezoneCode}, Europe, 0),Europe), $REPLACE(${GA4_ENDPOINT_HOSTNAME},www.google-analytics.com,region1.google-analytics.com), ${GA4_ENDPOINT_HOSTNAME}))"
+        "endpoint": "$IF(${DISABLE_REGIONAL_DATA_COLLECTION},https://${GA4_ENDPOINT_HOSTNAME}, https://$IF($EQUALS($MATCH(${timezoneCode}, Europe, 0),Europe), $REPLACE(${GA4_ENDPOINT_HOSTNAME},www.google-analytics.com,region1.google-analytics.com), ${GA4_ENDPOINT_HOSTNAME}))",
+	"ga4SessionCookie": "$CALC(SESSION_TIMESTAMP, 1000, divide, true).SESSION_COUNT.$IF($EQUALS(SESSION_ENGAGED, true),1,0).$CALC(TIMESTAMP, 1000, divide, true).0.0.0"
     },
     "extraUrlParams": {
         "sid": "$CALC(SESSION_TIMESTAMP, 1000, divide, true)",


### PR DESCRIPTION
Added cross-domain support for GA4.
Including the transmission of the client id, session id, session count and session engagement data