### PR TITLE
Remove last comma from first example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Just add the following code to your AMP Pages: ( check the table below for a ful
     "DEFAULT_PAGEVIEW_ENABLED": true,
     "SEND_DOUBLECLICK_BEACON": false,
     "DISABLE_REGIONAL_DATA_COLLECTION": false,
-    "ENHANCED_MEASUREMENT_SCROLL": false,
+    "ENHANCED_MEASUREMENT_SCROLL": false
   }
 }
 </script>


### PR DESCRIPTION
The last comma in the README example makes the vars structure not a valid json. So I propose to remove it as README is mostly used as initial trail (then you read the documentation).